### PR TITLE
Support for java 1.8

### DIFF
--- a/startcode/pom.xml
+++ b/startcode/pom.xml
@@ -12,7 +12,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.0</version>
 				<configuration>
-					<release>12</release>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Changed the release version to 1.8 in order to allow maven builds with java 1.8 installed.